### PR TITLE
Allow specifying a 'primary' domain for the certificate

### DIFF
--- a/ACME-PS/TypeDefinitions.ps1
+++ b/ACME-PS/TypeDefinitions.ps1
@@ -19,6 +19,7 @@ public interface ICertificateKey : ISigningKey
 {
     byte[] ExportPfx(byte[] acmeCertificate, System.Security.SecureString password);
     byte[] GenerateCsr(string[] dnsNames);
+    byte[] GenerateCsr(string primaryDomain, string[] dnsNames);
 }
 "@
 

--- a/ACME-PS/TypeDefinitions.ps1
+++ b/ACME-PS/TypeDefinitions.ps1
@@ -18,7 +18,6 @@ public interface IAccountKey : ISigningKey { }
 public interface ICertificateKey : ISigningKey
 {
     byte[] ExportPfx(byte[] acmeCertificate, System.Security.SecureString password);
-    byte[] GenerateCsr(string[] dnsNames);
     byte[] GenerateCsr(string primaryDomain, string[] dnsNames);
 }
 "@

--- a/ACME-PS/functions/CertificateKey/New-CertificateKey.ps1
+++ b/ACME-PS/functions/CertificateKey/New-CertificateKey.ps1
@@ -87,7 +87,7 @@ function New-CertificateKey {
     }
 
     if($PSCmdlet.ParameterSetName -eq "ECDsa") {
-        $certificateKey = [ICertificateKey]([ECDsaCertifiaceKey]::new($ECDsaHashSize));
+        $certificateKey = [ICertificateKey]([ECDsaCertificateKey]::new($ECDsaHashSize));
         Write-Verbose "Created new ECDsa certificate key with hash size $ECDsaHashSize";
     } else {
         $certificateKey = [ICertificateKey]([RSACertificateKey]::new($RSAHashSize, $RSAKeySize));

--- a/ACME-PS/functions/Order/Complete-Order.ps1
+++ b/ACME-PS/functions/Order/Complete-Order.ps1
@@ -43,6 +43,11 @@ function Complete-Order {
         $CertificateKey,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PrimaryDomain,
+
+        [Parameter()]
         [switch]
         $PassThru
     )
@@ -52,7 +57,15 @@ function Complete-Order {
 
         $dnsNames = $Order.Identifiers | ForEach-Object { $_.Value }
 
-        $csr = $CertificateKey.GenerateCsr($dnsNames);
+        if ($PrimaryDomain -and $dnsNames -icontains $PrimaryDomain) {
+            Write-Verbose "Generating CSR for $PrimaryDomain"
+            $csr = $CertificateKey.GenerateCsr($PrimaryDomain, $dnsNames);
+        }
+        else {
+            Write-Verbose "Generating CSR"
+            $csr = $CertificateKey.GenerateCsr($dnsNames);
+        }
+
         $payload = @{ "csr"= (ConvertTo-UrlBase64 -InputBytes $csr) }
 
         $requestUrl = $Order.FinalizeUrl;

--- a/ACME-PS/functions/Order/Complete-Order.ps1
+++ b/ACME-PS/functions/Order/Complete-Order.ps1
@@ -17,6 +17,9 @@ function Complete-Order {
         .PARAMETER CertificateKey
             The certificate key to be used to create the certificate signing request.
 
+        .PARAMETER PrimaryDomain
+            The domain to be used for the Subject of the certificate. If not supplied, the information supplied to New-Order will be used instead.
+
         .PARAMETER PassThru
             Forces the order to be returned to the pipeline.
 
@@ -62,8 +65,8 @@ function Complete-Order {
             $csr = $CertificateKey.GenerateCsr($PrimaryDomain, $dnsNames);
         }
         else {
-            Write-Verbose "Generating CSR"
-            $csr = $CertificateKey.GenerateCsr($dnsNames);
+            Write-Verbose "Generating CSR for $($Order.PrimaryDomain)"
+            $csr = $CertificateKey.GenerateCsr($Order.PrimaryDomain, $dnsNames);
         }
 
         $payload = @{ "csr"= (ConvertTo-UrlBase64 -InputBytes $csr) }

--- a/ACME-PS/functions/Order/Complete-Order.ps1
+++ b/ACME-PS/functions/Order/Complete-Order.ps1
@@ -17,12 +17,8 @@ function Complete-Order {
         .PARAMETER CertificateKey
             The certificate key to be used to create the certificate signing request.
 
-        .PARAMETER PrimaryDomain
-            The domain to be used for the Subject of the certificate. If not supplied, the information supplied to New-Order will be used instead.
-
         .PARAMETER PassThru
             Forces the order to be returned to the pipeline.
-
 
         .EXAMPLE
             PS> Complete-Order -State $myState -Order $myOrder -CertificateKey $myCertKey
@@ -46,11 +42,6 @@ function Complete-Order {
         $CertificateKey,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $PrimaryDomain,
-
-        [Parameter()]
         [switch]
         $PassThru
     )
@@ -60,14 +51,8 @@ function Complete-Order {
 
         $dnsNames = $Order.Identifiers | ForEach-Object { $_.Value }
 
-        if ($PrimaryDomain -and $dnsNames -icontains $PrimaryDomain) {
-            Write-Verbose "Generating CSR for $PrimaryDomain"
-            $csr = $CertificateKey.GenerateCsr($PrimaryDomain, $dnsNames);
-        }
-        else {
-            Write-Verbose "Generating CSR for $($Order.PrimaryDomain)"
-            $csr = $CertificateKey.GenerateCsr($Order.PrimaryDomain, $dnsNames);
-        }
+        Write-Verbose "Generating CSR for $($Order.PrimaryDomain)"
+        $csr = $CertificateKey.GenerateCsr($Order.PrimaryDomain, $dnsNames);
 
         $payload = @{ "csr"= (ConvertTo-UrlBase64 -InputBytes $csr) }
 

--- a/ACME-PS/internal/classes/AcmeOrder.ps1
+++ b/ACME-PS/internal/classes/AcmeOrder.ps1
@@ -6,6 +6,9 @@ class AcmeOrder {
         $this.NotAfter = $obj.NotAfter;
 
         $this.Identifiers = $obj.Identifiers | ForEach-Object { [AcmeIdentifier]::new($_) };
+        if ([string]::IsNullOrWhiteSpace($this.PrimaryDomain)) {
+            $this.PrimaryDomain = $this.Identifiers[0].Value
+        }
 
         $this.AuthorizationUrls = $obj.AuthorizationUrls;
         $this.FinalizeUrl = $obj.FinalizeUrl;
@@ -27,6 +30,9 @@ class AcmeOrder {
         $this.NotAfter = $httpResponse.Content.NotAfter;
 
         $this.Identifiers = $httpResponse.Content.Identifiers | ForEach-Object { [AcmeIdentifier]::new($_) };
+        if ([string]::IsNullOrWhiteSpace($this.PrimaryDomain)) {
+            $this.PrimaryDomain = $this.Identifiers[0].Value
+        }
 
         $this.AuthorizationUrls = $httpResponse.Content.Authorizations;
         $this.FinalizeUrl = $httpResponse.Content.Finalize;
@@ -49,6 +55,7 @@ class AcmeOrder {
     [Nullable[System.DateTimeOffset]] $NotAfter;
 
     [AcmeIdentifier[]] $Identifiers;
+    [string] $PrimaryDomain
 
     [string[]] $AuthorizationUrls;
     [string] $FinalizeUrl;

--- a/ACME-PS/internal/classes/crypto/Certificate.ps1
+++ b/ACME-PS/internal/classes/crypto/Certificate.ps1
@@ -51,17 +51,4 @@ class Certificate {
         $certRequest.CertificateExtensions.Add($sanBuilder.Build());
         return $certRequest.CreateSigningRequest();
     }
-
-    static [byte[]] GenerateCsr( [string[]] $dnsNames,
-        [System.Security.Cryptography.AsymmetricAlgorithm] $algorithm, [System.Security.Cryptography.HashAlgorithmName] $hashName)
-    {
-        if(-not $dnsNames) {
-            throw [System.ArgumentException]::new("You need to provide at least one DNSName", "dnsNames");
-        }
-
-        return GenerateCsr($dnsNames[0], $dnsNames, $algorithm, $hashName)
-
-    }
-
-
 }

--- a/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
+++ b/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
@@ -109,6 +109,11 @@ class ECDsaCertificateKey : ECDsaAccountKey, ICertificateKey {
         return [Certificate]::GenerateCsr($dnsNames, $this.ECDsa, $this.HashName);
     }
 
+    [byte[]] GenerateCsr([string] $primaryDomain, [string[]] $dnsNames) {
+        return [Certificate]::GenerateCsr($primaryDomain, $dnsNames, $this.ECDsa, $this.HashName);
+    }
+
+
     static [ICertificateKey] Create([ECDsaKeyExport] $keyExport) {
         $keyParameters = [System.Security.Cryptography.ECParameters]::new();
 

--- a/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
+++ b/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
@@ -105,14 +105,9 @@ class ECDsaCertificateKey : ECDsaAccountKey, ICertificateKey {
         return [Certificate]::ExportPfx($acmeCertificate, $this.ECDsa, $password);
     }
 
-    [byte[]] GenerateCsr([string[]] $dnsNames) {
-        return [Certificate]::GenerateCsr($dnsNames, $this.ECDsa, $this.HashName);
-    }
-
     [byte[]] GenerateCsr([string] $primaryDomain, [string[]] $dnsNames) {
         return [Certificate]::GenerateCsr($primaryDomain, $dnsNames, $this.ECDsa, $this.HashName);
     }
-
 
     static [ICertificateKey] Create([ECDsaKeyExport] $keyExport) {
         $keyParameters = [System.Security.Cryptography.ECParameters]::new();

--- a/ACME-PS/internal/classes/crypto/RSAKey.ps1
+++ b/ACME-PS/internal/classes/crypto/RSAKey.ps1
@@ -102,6 +102,10 @@ class RSACertificateKey : RSAAccountKey, ICertificateKey {
         return [Certificate]::GenerateCsr($dnsNames, $this.RSA, $this.HashName);
     }
 
+    [byte[]] GenerateCsr([string] $primaryDomain, [string[]] $dnsNames) {
+        return [Certificate]::GenerateCsr($primaryDomain, $dnsNames, $this.RSA, $this.HashName);
+    }
+
     static [ICertificateKey] Create([RSAKeyExport] $keyExport) {
         $keyParameters = [System.Security.Cryptography.RSAParameters]::new();
 

--- a/ACME-PS/internal/classes/crypto/RSAKey.ps1
+++ b/ACME-PS/internal/classes/crypto/RSAKey.ps1
@@ -98,10 +98,6 @@ class RSACertificateKey : RSAAccountKey, ICertificateKey {
         return [Certificate]::ExportPfx($acmeCertificate, $this.RSA, $password);
     }
 
-    [byte[]] GenerateCsr([string[]] $dnsNames) {
-        return [Certificate]::GenerateCsr($dnsNames, $this.RSA, $this.HashName);
-    }
-
     [byte[]] GenerateCsr([string] $primaryDomain, [string[]] $dnsNames) {
         return [Certificate]::GenerateCsr($primaryDomain, $dnsNames, $this.RSA, $this.HashName);
     }


### PR DESCRIPTION
Currently the ordering of domains supplied to `New-ACMEOrder` is not preserved, because the `AcmeOrder` object is created from the server response which, in practice, appears to return the Identifiers sorted alphabetically. 

These updates:
- Add a `PrimaryDomain` field to the `AcmeOrder` class
- Updates `AcmeOrder` constructor logic to initialize `PrimaryDomain` to the first `Identifier` so it should be compatible with old CliXML exports.
- Add a `PrimaryDomain` parameter to the `New-Order` cmdlet
- Updates the logic of the `New-Order` cmdlet to set the initial value of `PrimaryDomain` on the `AcmeOrder` to the value of the `PrimaryDomain` parameter if specified, or the value of the first supplied `Identifier` otherwise.
- Add a `primaryDomain` parameter to the `GenerateCsr` method that is used as the CN/Subject of the certificate