### PR TITLE
Allow defining the cn

### DIFF
--- a/ACME-PS/ACME-PS.psd1
+++ b/ACME-PS/ACME-PS.psd1
@@ -1,6 +1,6 @@
 @{
 	RootModule = 'ACME-PS.psm1'
-	ModuleVersion = '1.0.4'
+	ModuleVersion = '1.0.5'
 	GUID = '2DBF7E3F-F830-403A-9300-78A11C7CD00C'
 
 	CompatiblePSEditions = @("Core", "Desktop")
@@ -63,7 +63,6 @@
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 	PrivateData = @{
 		PSData = @{
-
 			# Tags applied to this module. These help with module discovery in online galleries.
 			Tags = @('pki','ssl','tls','security','certificates','letsencrypt','acme','powershell','acmesharp')
 
@@ -78,6 +77,9 @@
 
 			# ReleaseNotes of this module
 			ReleaseNotes = 'Please see the release notes from the release distribution page: https://github.com/PKISharp/ACMESharpCore-PowerShell/releases'
+
+			# Prerelase
+			Prerelease = 'beta1'
 		} # End of PSData hashtable
 
 	} # End of PrivateData hashtable

--- a/ACME-PS/ACME-PS.psm1
+++ b/ACME-PS/ACME-PS.psm1
@@ -65,6 +65,7 @@ $classes = @(
     "AcmeAccount",
     "AcmeIdentifier",
     "AcmeChallenge",
+    "AcmeCsrOptions"
     "AcmeOrder",
     "AcmeAuthorization",
     "AcmeState"

--- a/ACME-PS/TypeDefinitions.ps1
+++ b/ACME-PS/TypeDefinitions.ps1
@@ -18,7 +18,7 @@ public interface IAccountKey : ISigningKey { }
 public interface ICertificateKey : ISigningKey
 {
     byte[] ExportPfx(byte[] acmeCertificate, System.Security.SecureString password);
-    byte[] GenerateCsr(string[] dnsNames);
+    byte[] GenerateCsr(string[] dnsNames, string distinguishedName);
 }
 "@
 

--- a/ACME-PS/functions/Order/Complete-Order.ps1
+++ b/ACME-PS/functions/Order/Complete-Order.ps1
@@ -51,8 +51,13 @@ function Complete-Order {
         $ErrorActionPreference = 'Stop';
 
         $dnsNames = $Order.Identifiers | ForEach-Object { $_.Value }
+        if($Order.CSROptions -and -not [string]::IsNullOrWhiteSpace($Order.CSROptions.DistinguishedName)) {
+            $certDN = $Order.CSROptions.DistinguishedName;
+        } else {
+            $certDN = "CN=$($Order.Identifiers[0].Value)"
+        }
 
-        $csr = $CertificateKey.GenerateCsr($dnsNames);
+        $csr = $CertificateKey.GenerateCsr($dnsNames, $certDN);
         $payload = @{ "csr"= (ConvertTo-UrlBase64 -InputBytes $csr) }
 
         $requestUrl = $Order.FinalizeUrl;

--- a/ACME-PS/internal/classes/AcmeCsrOptions.ps1
+++ b/ACME-PS/internal/classes/AcmeCsrOptions.ps1
@@ -1,0 +1,9 @@
+class AcmeCsrOptions {
+    AcmeCsrOptions() { }
+
+    AcmeCsrOptions([PsCustomObject] $obj) {
+        $this.DistinguishedName = $obj.DistinguishedName
+    }
+
+    [string]$DistinguishedName;
+}

--- a/ACME-PS/internal/classes/AcmeOrder.ps1
+++ b/ACME-PS/internal/classes/AcmeOrder.ps1
@@ -12,11 +12,19 @@ class AcmeOrder {
         $this.CertificateUrl = $obj.CertificateUrl;
 
         $this.ResourceUrl = $obj.ResourceUrl;
+        $this.CSROptions = if($obj.CSROptions) {$obj.CSROptions} else {@{}};
     }
 
     AcmeOrder([AcmeHttpResponse] $httpResponse)
     {
         $this.UpdateOrder($httpResponse)
+        $this.CSROptions = @{}
+    }
+
+    AcmeOrder([AcmeHttpResponse] $httpResponse, [hashtable] $csrOptions)
+    {
+        $this.UpdateOrder($httpResponse)
+        $this.CSROptions = if($csrOptions) {$csrOptions} else {@{}};
     }
 
     [void] UpdateOrder([AcmeHttpResponse] $httpResponse) {
@@ -49,6 +57,7 @@ class AcmeOrder {
     [Nullable[System.DateTimeOffset]] $NotAfter;
 
     [AcmeIdentifier[]] $Identifiers;
+    [hashtable] $CSROptions;
 
     [string[]] $AuthorizationUrls;
     [string] $FinalizeUrl;

--- a/ACME-PS/internal/classes/AcmeOrder.ps1
+++ b/ACME-PS/internal/classes/AcmeOrder.ps1
@@ -12,19 +12,29 @@ class AcmeOrder {
         $this.CertificateUrl = $obj.CertificateUrl;
 
         $this.ResourceUrl = $obj.ResourceUrl;
-        $this.CSROptions = if($obj.CSROptions) {$obj.CSROptions} else {@{}};
+
+        if($obj.CSROptions) {
+            $this.CSROptions = [AcmeCsrOptions]::new($obj.CSROptions)
+        } else {
+            $this.CSROptions = [AcmeCsrOptions]::new()
+        }
     }
 
     AcmeOrder([AcmeHttpResponse] $httpResponse)
     {
         $this.UpdateOrder($httpResponse)
-        $this.CSROptions = @{}
+        $this.CSROptions = [AcmeCsrOptions]::new();
     }
 
-    AcmeOrder([AcmeHttpResponse] $httpResponse, [hashtable] $csrOptions)
+    AcmeOrder([AcmeHttpResponse] $httpResponse, [AcmeCsrOptions] $csrOptions)
     {
         $this.UpdateOrder($httpResponse)
-        $this.CSROptions = if($csrOptions) {$csrOptions} else {@{}};
+
+        if($csrOptions) {
+            $this.CSROptions = $csrOptions;
+        } else {
+            $this.CSROptions = [AcmeCSROptions]::new()
+        }
     }
 
     [void] UpdateOrder([AcmeHttpResponse] $httpResponse) {
@@ -57,10 +67,11 @@ class AcmeOrder {
     [Nullable[System.DateTimeOffset]] $NotAfter;
 
     [AcmeIdentifier[]] $Identifiers;
-    [hashtable] $CSROptions;
 
     [string[]] $AuthorizationUrls;
     [string] $FinalizeUrl;
 
     [string] $CertificateUrl;
+
+    [AcmeCsrOptions] $CSROptions;
 }

--- a/ACME-PS/internal/classes/AcmeState.ps1
+++ b/ACME-PS/internal/classes/AcmeState.ps1
@@ -164,7 +164,7 @@ class AcmeState {
 
             $order | Export-AcmeObject $orderFileName -Force;
         } else {
-            Write-Warning "If AutoSaving is off, this method does nothing."
+            Write-Warning "auto saving the state has been disabled, so set order is a no-op".
         }
     }
 
@@ -180,7 +180,7 @@ class AcmeState {
             $orderListFile = $this.Filenames.OrderList;
             Set-Content -Path $orderListFile -Value (Get-Content -Path $orderListFile | Select-String -Pattern "=$orderHash" -NotMatch -SimpleMatch)
         } else {
-            Write-Warning "If AutoSaving is off, this method does nothing."
+            Write-Warning "auto saving the state has been disabled, so set order is a no-op".
         }
     }
 

--- a/ACME-PS/internal/classes/AcmeState.ps1
+++ b/ACME-PS/internal/classes/AcmeState.ps1
@@ -164,7 +164,7 @@ class AcmeState {
 
             $order | Export-AcmeObject $orderFileName -Force;
         } else {
-            Write-Warning "auto saving the state has been disabled, so set order is a no-op".
+            Write-Warning "auto saving the state has been disabled, so set order is a no-op."
         }
     }
 
@@ -180,7 +180,7 @@ class AcmeState {
             $orderListFile = $this.Filenames.OrderList;
             Set-Content -Path $orderListFile -Value (Get-Content -Path $orderListFile | Select-String -Pattern "=$orderHash" -NotMatch -SimpleMatch)
         } else {
-            Write-Warning "auto saving the state has been disabled, so set order is a no-op".
+            Write-Warning "auto saving the state has been disabled, so set order is a no-op."
         }
     }
 

--- a/ACME-PS/internal/classes/crypto/Certificate.ps1
+++ b/ACME-PS/internal/classes/crypto/Certificate.ps1
@@ -19,11 +19,15 @@ class Certificate {
         }
     }
 
-    static [byte[]] GenerateCsr([string[]] $dnsNames,
-        [System.Security.Cryptography.AsymmetricAlgorithm] $algorithm, [System.Security.Cryptography.HashAlgorithmName] $hashName)
+    static [byte[]] GenerateCsr([string[]] $dnsNames, [string]$distinguishedName,
+        [System.Security.Cryptography.AsymmetricAlgorithm] $algorithm, 
+        [System.Security.Cryptography.HashAlgorithmName] $hashName)
     {
         if(-not $dnsNames) {
             throw [System.ArgumentException]::new("You need to provide at least one DNSName", "dnsNames");
+        }
+        if(-not $distinguishedName) {
+            thtow [System.ArgumentException]::new("Provide a distinguishedName for the Certificate")
         }
 
         $sanBuilder = [System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder]::new();
@@ -31,17 +35,17 @@ class Certificate {
             $sanBuilder.AddDnsName($dnsName);
         }
 
-        $distinguishedName = [X500DistinguishedName]::new("CN=$($dnsNames[0])");
+        $certDN = [X500DistinguishedName]::new($distinguishedName);
 
         [System.Security.Cryptography.X509Certificates.CertificateRequest]$certRequest = $null;
 
         if($algorithm -is [System.Security.Cryptography.RSA]) {
             $certRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-                    $distinguishedName, $algorithm, $hashName, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1);
+                    $certDN, $algorithm, $hashName, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1);
         }
         elseif($algorithm -is [System.Security.Cryptography.ECDsa]) {
             $certRequest = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-                $distinguishedName, $algorithm, $hashName);
+                $certDN, $algorithm, $hashName);
 
         }
         else {

--- a/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
+++ b/ACME-PS/internal/classes/crypto/ECDsaKey.ps1
@@ -105,8 +105,8 @@ class ECDsaCertificateKey : ECDsaAccountKey, ICertificateKey {
         return [Certificate]::ExportPfx($acmeCertificate, $this.ECDsa, $password);
     }
 
-    [byte[]] GenerateCsr([string[]] $dnsNames) {
-        return [Certificate]::GenerateCsr($dnsNames, $this.ECDsa, $this.HashName);
+    [byte[]] GenerateCsr([string[]] $dnsNames, [string] $distinguishedName) {
+        return [Certificate]::GenerateCsr($dnsNames, $distinguishedName, $this.ECDsa, $this.HashName);
     }
 
     static [ICertificateKey] Create([ECDsaKeyExport] $keyExport) {

--- a/ACME-PS/internal/classes/crypto/RSAKey.ps1
+++ b/ACME-PS/internal/classes/crypto/RSAKey.ps1
@@ -98,8 +98,8 @@ class RSACertificateKey : RSAAccountKey, ICertificateKey {
         return [Certificate]::ExportPfx($acmeCertificate, $this.RSA, $password);
     }
 
-    [byte[]] GenerateCsr([string[]] $dnsNames) {
-        return [Certificate]::GenerateCsr($dnsNames, $this.RSA, $this.HashName);
+    [byte[]] GenerateCsr([string[]] $dnsNames, [string] $distinguishedName) {
+        return [Certificate]::GenerateCsr($dnsNames, $distinguishedName, $this.RSA, $this.HashName);
     }
 
     static [ICertificateKey] Create([RSAKeyExport] $keyExport) {

--- a/ACME-PS/tests/A-Manual-Test-Run.ps1
+++ b/ACME-PS/tests/A-Manual-Test-Run.ps1
@@ -1,7 +1,11 @@
-$ModuleBase = Split-Path -Path $PSScriptRoot -Parent
+try {
+    $ModuleBase = Split-Path -Path $PSScriptRoot -Parent
 
-Remove-Module ACME-PS -ErrorAction Ignore
-Import-Module "$ModuleBase\ACME-PS.psd1"
-#Import-Module "$ModuleBase\ACME-PS.psm1" -DisableNameChecking
+    Remove-Module ACME-PS -ErrorAction Ignore
+    Import-Module "$ModuleBase\ACME-PS.psd1" -ErrorAction 'Stop'
 
-Invoke-Pester -Path "$ModuleBase\tests"
+    Invoke-Pester -Path "$ModuleBase\tests"
+}
+catch {
+    Write-Error $error[0];
+}

--- a/ACME-PS/tests/New-Order.Tests.ps1
+++ b/ACME-PS/tests/New-Order.Tests.ps1
@@ -1,0 +1,50 @@
+InModuleScope ACME-PS {
+    Describe "UnitTesting New-Order" -Tag "UnitTest" {
+        Mock Invoke-AcmeWebRequest {
+            $mockResult = [AcmeHttpResponse]::new();
+            $mockResult.NextNonce = "NextNonce";
+            return  $mockResult;
+        } -Verifiable -ParameterFilter {
+            $Url -eq $state.GetServiceDirectory().NewOrder -and
+            $Method -eq "POST"
+        }
+
+        $state = Get-State -Path $PSScriptRoot\states\simple
+        $state.AutoSave = $false;
+
+        $identifiers = @(
+            New-ACMEIdentifier "www.example2.com";
+            New-ACMEIdentifier "www.example1.com";
+        )
+
+        Context 'Mandatory parameters only' {
+            $order = New-Order $state -Identifiers $identifiers
+
+            It 'called the ACME service' {
+                Assert-VerifiableMock
+            }
+    
+            It 'sets the nonce in $state' {
+                $state.GetNonce() | Should -Be "NextNonce";
+            }
+
+            It 'set the first identifier as CertDN' {
+                $order.CSROptions.DistinguishedName | Should -Be "CN=www.example2.com";
+            }
+        }
+        
+        Context 'Mandatory parameters and CertDN' {
+            $order = New-Order $state -Identifiers $identifiers -CertDN "CN=MyTestDN"
+
+            It 'used the certCN for the options' {
+                $order.CSROptions.DistinguishedName | Should -Be "CN=MyTestDN";
+            }
+        }
+
+        Context 'Exceptions' {
+            It 'does not accept wrong CertDNs' {
+               { New-Order $state -Identifiers $identifiers -CertDN "invalid" } | Should -Throw;
+            }
+        }
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -24,8 +24,6 @@ if(Test-Path $ModuleOutPath) {
 }
 
 <# Publish the module #>
-Import-Module "$PSScriptRoot/ACME-PS" -Force -ErrorAction 'Stop' -Verbose:$false # This will create the All* files.
-
 Write-Information "Copying $ModuleSourcePath/ACME-PS.psd1"
 Copy-Item -Path "$ModuleSourcePath/ACME-PS.psd1" -Destination "$ModuleOutPath/" -Force;
 
@@ -34,6 +32,9 @@ Copy-Item -Path "$ModuleSourcePath/TypeDefinitions.ps1" -Destination "$ModuleOut
 
 Write-Information "Copying $ModuleSourcePath/Prerequisites.ps1"
 Copy-Item -Path "$ModuleSourcePath/Prerequisites.ps1" -Destination "$ModuleOutPath/" -Force;
+
+
+Import-Module "$PSScriptRoot/ACME-PS" -Force -ErrorAction 'Stop' -Verbose:$false # This will create the All* files.
 
 $ModuleFiles = @(
     "internal/AllClasses.ps1",


### PR DESCRIPTION
This allows CSR settings to be stored with the order.
Currently the settings consist only of the DistinguishedName, which will either be the first identifier which is passed to New-Order or the Content of the parameter you provide with -CertDN

Thanks to @casselc for some input via his PR #17 