### PR TITLE
Fix return value in New-Account

### DIFF
--- a/ACME-PS/functions/Account/New-Account.ps1
+++ b/ACME-PS/functions/Account/New-Account.ps1
@@ -85,7 +85,7 @@ function New-Account {
         $State.Set($account);
 
         if($PassThru) {
-            return $result;
+            return $account;
         }
     }
 }


### PR DESCRIPTION
Fixes `New-Account` returning null with `-PassThru` enabled.