### PR TITLE
Specify -UseBasicParsing when getting directory

### DIFF
--- a/ACME-PS/functions/ServiceDirectory/Get-ServiceDirectory.ps1
+++ b/ACME-PS/functions/ServiceDirectory/Get-ServiceDirectory.ps1
@@ -84,7 +84,7 @@ function Get-ServiceDirectory {
                 $serviceDirectoryUrl = $DirectoryUrl
             }
 
-            $response = Invoke-WebRequest $serviceDirectoryUrl;
+            $response = Invoke-WebRequest $serviceDirectoryUrl -UseBasicParsing;
 
             $result = [AcmeDirectory]::new(($response.Content | ConvertFrom-Json));
             $result.ResourceUrl = $serviceDirectoryUrl;


### PR DESCRIPTION
This is the default behaviour in PowerShell 6 (the switch is deprecated and ignored). PowerShell 5 requires Internet Explorer to call `Invoke-WebRequest` unless `-UseBasicParsing` is specified.

This is an issue in PS 5 environments where IE isn't available - specifically I've run into this in Azure Automation.