### PR TITLE
Update AzureRunbookExample.ps1 example code

### DIFF
--- a/samples/AzureRunbookExample.ps1
+++ b/samples/AzureRunbookExample.ps1
@@ -41,8 +41,8 @@ $certExportPathParent = "C:\app\certificates\";
 $certExportPath = "C:\app\certificates\certificate.pfx";
 
 # ServiceName (valid names are LetsEncrypt and LetsEncrypt-Staging, use the latter one for testing your scripts).
-# $acmeServiceName = "LetsEncrypt-Staging";
-$acmeServiceName = "LetsEncrypt";
+$acmeServiceName = "LetsEncrypt-Staging";
+# $acmeServiceName = "LetsEncrypt";
 
 
 function PublishWebsiteFile

--- a/samples/AzureRunbookExample.ps1
+++ b/samples/AzureRunbookExample.ps1
@@ -42,7 +42,7 @@ $certExportPath = "C:\app\certificates\certificate.pfx";
 
 # ServiceName (valid names are LetsEncrypt and LetsEncrypt-Staging, use the latter one for testing your scripts).
 $acmeServiceName = "LetsEncrypt-Staging";
-# $acmeServiceName = "LetsEncrypt";
+#$acmeServiceName = "LetsEncrypt";
 
 
 function PublishWebsiteFile
@@ -288,10 +288,6 @@ try
     }
 
     $securePassword = ConvertTo-SecureString "XXX" –asplaintext –force
-    Start-Sleep -Seconds 30
-    
-    "Checking Files in C:\Temp\certificates\"
-    Get-ChildItem $certExportPathParent
 
     "Exporting..."
 
@@ -301,12 +297,10 @@ try
         -Path $certExportPath `
         -Password $securePassword
 
-    Start-Sleep -Seconds 30
-    "Exporting completed..."
-
     "Checking Files in C:\Temp\certificates\"
     Get-ChildItem $certExportPathParent
 
+    "Exporting completed..."
     "🚀 Wohoo! Apply new SSL Binding to $WebApp..."
     New-AzWebAppSSLBinding -ResourceGroupName $ResourceGroupName `
         -WebAppName $WebApp `

--- a/samples/AzureRunbookExample.ps1
+++ b/samples/AzureRunbookExample.ps1
@@ -31,7 +31,7 @@ param(
 )
 
 # Your email addresses, where acme services will send informations.
-$contactMailAddresses = @($RegistrationEmail);
+$contactMailAddresses = @($RegistrationEmail, "second-mail@example.org");
 
 # This directory is used to store your account key and service directory urls as well as orders and related data
 $acmeStateDir = "C:\app\AcmeState";
@@ -283,7 +283,7 @@ try
 
     # Now we wait until the ACME service provides the certificate url
     while(-not $order.CertificateUrl) {
-        Start-Sleep -Seconds 45
+        Start-Sleep -Seconds 15
         $order | Update-ACMEOrder -State $acmeStateDir -PassThru
     }
 


### PR DESCRIPTION
I have update the script with some small changes that I explain here:

- Updated the AzureRunbookExample.ps1 to create the folder where the certificate is saved
-  Use the new Az powershell modules instead of using the old AzureRM modules
-  The script will connect using the automation account managed identity because RunAsAccount is [deprecated](https://learn.microsoft.com/en-us/azure/automation/migrate-run-as-accounts-managed-identity?tabs=sa-managed-identity)
- Add a paramter to connect to one particular Azure subscription

Fix #142 